### PR TITLE
Fix Python 3 compatibility and update pandas dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,6 @@ install:
   pip install -r requirements-dev.txt
 
 script:
-  py.test
+  - py.test
+  - python scripts/fast_dawid_skene.py --dataset toy --k 2 --mode aggregate --algorithm FDS --print_result
+  - python scripts/fast_dawid_skene.py --dataset toy --mode aggregate --algorithm FDS --print_result

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ install:
 
 script:
   - py.test
-  - python scripts/fast_dawid_skene.py --dataset toy --k 2 --mode aggregate --algorithm FDS --print_result
-  - python scripts/fast_dawid_skene.py --dataset toy --mode aggregate --algorithm FDS --print_result
+  - python scripts/fast_dawid_skene.py --dataset toy --k 2 --mode aggregate --algorithm FDS --print_result --verbose
+  - python scripts/fast_dawid_skene.py --dataset toy --mode aggregate --algorithm FDS --print_result --verbose

--- a/fast_dawid_skene/algorithms.py
+++ b/fast_dawid_skene/algorithms.py
@@ -96,7 +96,7 @@ def run(responses, args, tol=0.0001, CM_tol=0.005, max_iter=100):
     # total_time = 0
 
     if args.verbose:
-        print "Iter\tlog-likelihood\tdelta-CM\tdelta-ER"
+        print("Iter\tlog-likelihood\tdelta-CM\tdelta-ER")
 
     while not converged:
         nIter += 1
@@ -123,24 +123,25 @@ def run(responses, args, tol=0.0001, CM_tol=0.005, max_iter=100):
                 np.abs(class_marginals - old_class_marginals))
             error_rates_diff = np.sum(np.abs(error_rates - old_error_rates))
             if args.verbose:
-                print nIter, '\t', log_L, '\t%.6f\t%.6f' % (class_marginals_diff, error_rates_diff)
+                print(nIter, '\t', log_L, '\t%.6f\t%.6f' %
+                      (class_marginals_diff, error_rates_diff))
             if (class_marginals_diff < tol) or nIter >= max_iter:
                 converged = True
             elif (mode == 'H' and class_marginals_diff <= CM_tol):
                 if args.verbose:
-                    print "Mode changed to Hphase2"
+                    print("Mode changed to Hphase2")
                 mode = 'Hphase2'
         else:
             if args.verbose:
-                print nIter, '\t', log_L
+                print(nIter, '\t', log_L)
 
         old_class_marginals = class_marginals
         old_error_rates = error_rates
 
     np.set_printoptions(precision=2, suppress=True)
     if args.verbose:
-        print "Class marginals"
-        print class_marginals
+        print("Class marginals")
+        print(class_marginals)
 
     result = np.argmax(question_classes, axis=1)
 
@@ -161,7 +162,7 @@ def responses_to_counts(responses):
         counts: 3d array of counts: [questions x participants x classes]
     """
     questions = responses.keys()
-    questions.sort()
+    questions = sorted(questions)
     nQuestions = len(questions)
 
     # determine the participants and classes
@@ -367,7 +368,7 @@ def calc_likelihood(counts, class_marginals, error_rates):
 
         if np.isnan(temp) or np.isinf(temp):
             if args.verbose:
-                print i, log_L, np.log(patient_likelihood), temp
+                print(i, log_L, np.log(patient_likelihood), temp)
             sys.exit()
 
         log_L = temp

--- a/fast_dawid_skene/algorithms.py
+++ b/fast_dawid_skene/algorithms.py
@@ -19,6 +19,8 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 DEALINGS IN THE SOFTWARE.
 """
 
+from __future__ import print_function
+
 import numpy as np
 
 

--- a/fast_dawid_skene/loader.py
+++ b/fast_dawid_skene/loader.py
@@ -20,6 +20,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+from __future__ import print_function
+
 import numpy as np
 import pandas as pd
 import os

--- a/fast_dawid_skene/main.py
+++ b/fast_dawid_skene/main.py
@@ -20,6 +20,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+from __future__ import print_function
+
 import argparse
 import os
 import loader

--- a/fast_dawid_skene/utils.py
+++ b/fast_dawid_skene/utils.py
@@ -20,6 +20,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+from __future__ import print_function
+
 import csv
 import os
 import numpy as np

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 pytest==3.0.7
-pandas==0.20.1
+pandas==0.20.2
 numpy==1.13.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pandas==0.20.1
+pandas==0.20.2
 numpy==1.13.1


### PR DESCRIPTION
* Some parts of `algorithms.py` used Python 2 specific syntax. This has been fixed to allow use of Python 3.
* The pandas version 0.20.1 specified in requirements.txt had a [known bug](https://stackoverflow.com/a/46534274), which was reported in #4. Resolves #4 by updating the version to 0.20.2.